### PR TITLE
Accept capitalized versions of `true` and `false` literals. Fix #29

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,3 +4,5 @@
   https://github.com/tdammers/
 - **Alex Greif**  
   https://github.com/agreif/
+- **Wanja Chresta**
+  https://github.com/wchresta/

--- a/src/Text/Ginger/Parse.hs
+++ b/src/Text/Ginger/Parse.hs
@@ -1231,7 +1231,9 @@ varExprP = do
     litName <- identifierP
     spacesOrComment
     return $ case litName of
+        "True" -> BoolLiteralE pos True
         "true" -> BoolLiteralE pos True
+        "False" -> BoolLiteralE pos False
         "false" -> BoolLiteralE pos False
         "null" -> NullLiteralE pos
         _ -> VarE pos litName

--- a/test/Text/Ginger/SimulationTests.hs
+++ b/test/Text/Ginger/SimulationTests.hs
@@ -102,8 +102,12 @@ simulationTests = testGroup "Simulation"
         , testGroup "Booleans"
             [ testCase "true" $ mkTestHtml
                 [] [] "{{ true }}" "1"
+            , testCase "True" $ mkTestHtml
+                [] [] "{{ True }}" "1"
             , testCase "false" $ mkTestHtml
                 [] [] "{{ false }}" ""
+            , testCase "False" $ mkTestHtml
+                [] [] "{{ False }}" ""
             ]
         , testCase "Null" $ mkTestHtml
             [] [] "{{ null }}" ""


### PR DESCRIPTION
Fixes #29 by adding two cases for capitalised booleans.