### PR TITLE
Bump the optparse-applicative version ceiling

### DIFF
--- a/ginger.cabal
+++ b/ginger.cabal
@@ -72,7 +72,7 @@ executable ginger
                  , aeson >=1.4.2.0 && <1.6
                  , bytestring >=0.10.8.2 && <0.11
                  , data-default >= 0.5
-                 , optparse-applicative >=0.14.3.0 && <0.16
+                 , optparse-applicative >=0.14.3.0 && <0.17
                  , process >=1.6.5.0 && <1.7
                  , text >=1.2.3.1 && <1.3
                  , transformers >=0.5.6.2 && <0.6


### PR DESCRIPTION
Just the title - I ran into this when trying a new cabal freeze.