### PR TITLE
Fix GHC 9 simplified subsumption issue #66

### DIFF
--- a/src/Text/PrintfA.hs
+++ b/src/Text/PrintfA.hs
@@ -9,4 +9,4 @@ data PrintfArgT = forall a. PrintfArg a => P a
 data PrintfTypeT = T { unT :: forall r. PrintfType r => r }
 
 printfa :: PrintfType t => String -> [ PrintfArgT ] -> t
-printfa format = unT . foldl (\(T r) (P a) -> T $ r a ) (T $ printf format)
+printfa format = (\(T t) -> t) . foldl (\(T r) (P a) -> T $ r a ) (T $ printf format)


### PR DESCRIPTION
This change fixes the error described in issue #66.  Ginger now builds with GHC 9.0.1 without issue, with all tests passing.

This change should be compatible with previous versions of GHC.  I tested it against GHC 8.10.4 but not earlier versions.