### PR TITLE
Add support for Aeson 2 (#68)

### DIFF
--- a/ginger.cabal
+++ b/ginger.cabal
@@ -40,7 +40,7 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends: base >=4.8 && <5
-               , aeson >=1.4.2.0 && <1.6
+               , aeson >=1.4.2.0 && <2.1
                , aeson-pretty >=0.8.7 && <0.9
                , bytestring >=0.10.8.2 && <0.11
                , containers >=0.6.4 && <0.7
@@ -72,7 +72,7 @@ executable ginger
     default-language:    Haskell2010
     build-depends: base >= 4.8 && <5
                  , ginger
-                 , aeson >=1.4.2.0 && <1.6
+                 , aeson >=1.4.2.0 && <2.1
                  , bytestring >=0.10.8.2 && <0.11
                  , data-default >= 0.5
                  , optparse-applicative >=0.14.3.0 && <0.17
@@ -92,7 +92,7 @@ test-suite tests
     default-language: Haskell2010
     build-depends: base >=4.8 && <5
                  , ginger
-                 , aeson >=1.4.2.0 && <1.6
+                 , aeson >=1.4.2.0 && <2.1
                  , bytestring >=0.10.8.2 && <0.11
                  , data-default >=0.5
                  , mtl >=2.2.2 && <2.3


### PR DESCRIPTION
This commit defines a `ToGVal` instance for [KeyMap][] [Value][] when using Aeson 2 or newer.

[KeyMap]: <https://hackage.haskell.org/package/aeson-2.0.1.0/docs/Data-Aeson-KeyMap.html#t:KeyMap>
[Value]: <https://hackage.haskell.org/package/aeson-2.0.1.0/docs/Data-Aeson.html#t:Value>