### PR TITLE
Extend bytestring version upper bound

### DIFF
--- a/ginger.cabal
+++ b/ginger.cabal
@@ -42,7 +42,7 @@ library
   build-depends: base >=4.8 && <5
                , aeson >=1.4.2.0 && <2.1
                , aeson-pretty >=0.8.7 && <0.9
-               , bytestring >=0.10.8.2 && <0.11
+               , bytestring >=0.10.8.2 && <0.12
                , containers >=0.6.4 && <0.7
                , data-default >= 0.5
                , filepath >= 1.3
@@ -73,7 +73,7 @@ executable ginger
     build-depends: base >= 4.8 && <5
                  , ginger
                  , aeson >=1.4.2.0 && <2.1
-                 , bytestring >=0.10.8.2 && <0.11
+                 , bytestring >=0.10.8.2 && <0.12
                  , data-default >= 0.5
                  , optparse-applicative >=0.14.3.0 && <0.17
                  , process >=1.6.5.0 && <1.7
@@ -93,7 +93,7 @@ test-suite tests
     build-depends: base >=4.8 && <5
                  , ginger
                  , aeson >=1.4.2.0 && <2.1
-                 , bytestring >=0.10.8.2 && <0.11
+                 , bytestring >=0.10.8.2 && <0.12
                  , data-default >=0.5
                  , mtl >=2.2.2 && <2.3
                  , tasty >=1.2 && <1.5


### PR DESCRIPTION
GHC 9.2.1 includes `bytestring` `0.11.1.0` ([reference](https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/libraries/version-history)).  Ginger works fine with GHC 9.2.1 with this change.