### PR TITLE
Extend text version upper bound

### DIFF
--- a/ginger.cabal
+++ b/ginger.cabal
@@ -52,7 +52,7 @@ library
                , regex-tdfa >=1.2.3 && <=1.5
                , safe >= 0.3
                , scientific >= 0.3
-               , text >=1.2.3.1 && <1.3
+               , text >=1.2.3.1 && <2.1
                , time >= 0.1.6.0
                , transformers >= 0.3
                , unordered-containers >= 0.2.5
@@ -77,7 +77,7 @@ executable ginger
                  , data-default >= 0.5
                  , optparse-applicative >=0.14.3.0 && <0.17
                  , process >=1.6.5.0 && <1.7
-                 , text >=1.2.3.1 && <1.3
+                 , text >=1.2.3.1 && <2.1
                  , transformers >=0.5.6.2 && <0.6
                  , unordered-containers >= 0.2.5
                  , utf8-string >=1.0.1.1 && <1.1
@@ -99,7 +99,7 @@ test-suite tests
                  , tasty >=1.2 && <1.5
                  , tasty-hunit >=0.10.0.1 && <0.11
                  , tasty-quickcheck >=0.10 && <0.11
-                 , text >=1.2.3.1 && <1.3
+                 , text >=1.2.3.1 && <2.1
                  , time >= 0.1.6.0
                  , transformers >=0.5.6.2 && <0.6
                  , unordered-containers >= 0.2.5


### PR DESCRIPTION
Ginger works fine with [text 2.0][], so I extended the constraint bounds.

[text 2.0]: <https://hackage.haskell.org/package/text-2.0>