### PR TITLE
Extend optparse-applicative version upper bound

### DIFF
--- a/ginger.cabal
+++ b/ginger.cabal
@@ -75,7 +75,7 @@ executable ginger
                  , aeson >=1.4.2.0 && <2.1
                  , bytestring >=0.10.8.2 && <0.12
                  , data-default >= 0.5
-                 , optparse-applicative >=0.14.3.0 && <0.17
+                 , optparse-applicative >=0.14.3.0 && <0.18
                  , process >=1.6.5.0 && <1.7
                  , text >=1.2.3.1 && <2.1
                  , transformers >=0.5.6.2 && <0.6


### PR DESCRIPTION
Ginger works fine with [optparse-applicative-0.17.0.0](https://hackage.haskell.org/package/optparse-applicative-0.17.0.0), so I extended the constraint bounds.