### PR TITLE
Extend mtl and transformers version upper bounds

### DIFF
--- a/ginger.cabal
+++ b/ginger.cabal
@@ -78,7 +78,7 @@ executable ginger
                  , optparse-applicative >=0.14.3.0 && <0.18
                  , process >=1.6.5.0 && <1.7
                  , text >=1.2.3.1 && <2.1
-                 , transformers >=0.5.6.2 && <0.6
+                 , transformers >=0.5.6.2 && <0.7
                  , unordered-containers >= 0.2.5
                  , utf8-string >=1.0.1.1 && <1.1
                  , yaml >=0.11.0.0 && <0.12
@@ -95,12 +95,12 @@ test-suite tests
                  , aeson >=1.4.2.0 && <2.1
                  , bytestring >=0.10.8.2 && <0.12
                  , data-default >=0.5
-                 , mtl >=2.2.2 && <2.3
+                 , mtl >=2.2.2 && <2.4
                  , tasty >=1.2 && <1.5
                  , tasty-hunit >=0.10.0.1 && <0.11
                  , tasty-quickcheck >=0.10 && <0.11
                  , text >=1.2.3.1 && <2.1
                  , time >= 0.1.6.0
-                 , transformers >=0.5.6.2 && <0.6
+                 , transformers >=0.5.6.2 && <0.7
                  , unordered-containers >= 0.2.5
                  , utf8-string >=1.0.1.1 && <1.1

--- a/src/Text/Ginger/Run.hs
+++ b/src/Text/Ginger/Run.hs
@@ -95,7 +95,7 @@ import Text.Ginger.Run.VM
 import Text.Printf
 import Text.PrintfA
 import Text.Ginger.Parse (parseGinger, ParserError)
-import Control.Monad.Except (runExceptT, throwError, catchError)
+import Control.Monad.Trans.Except (runExceptT, catchE)
 
 import Data.Text (Text)
 import Data.String (fromString)
@@ -118,6 +118,7 @@ import Safe (readMay, lastDef, headMay)
 import Network.HTTP.Types (urlEncode)
 import Debug.Trace (trace)
 import Data.List (lookup, zipWith, unzip)
+import Data.Monoid (Monoid (..), (<>))
 import Data.Aeson as JSON
 
 defaultScope :: forall m h p
@@ -484,7 +485,7 @@ runStatement' (PreprocessedIncludeS _ tpl) =
     withTemplate tpl $ runTemplate tpl
 
 runStatement' (TryCatchS _ tryS catchesS finallyS) = do
-    result <- (runStatement tryS) `catchError` handle catchesS
+    result <- (runStatement tryS) `catchE` handle catchesS
     runStatement finallyS
     return result
     where

--- a/src/Text/Ginger/Run/Type.hs
+++ b/src/Text/Ginger/Run/Type.hs
@@ -80,7 +80,7 @@ import Text.Ginger.Parse (ParserError (..), sourceLine, sourceColumn, sourceName
 import Text.Printf
 import Text.PrintfA
 import Data.Scientific (formatScientific)
-import Control.Monad.Except (ExceptT (..))
+import Control.Monad.Trans.Except (ExceptT (..), runExceptT)
 import Data.Default (Default (..), def)
 
 import Data.Char (isSpace)
@@ -104,6 +104,7 @@ import Safe (readMay, lastDef, headMay)
 import Network.HTTP.Types (urlEncode)
 import Debug.Trace (trace)
 import Data.Maybe (isNothing)
+import Data.Monoid (Monoid (..), (<>))
 import Data.List (lookup, zipWith, unzip)
 
 -- | Execution context. Determines how to look up variables from the


### PR DESCRIPTION
This PR adds support for `mtl` 2.3 and `transformers` 0.6.  Most of the changes are simple changes/additions to imports.  The only other change has to do with use of the `MonadFail` instance of `ErrorT` in the regular expression support.  `ErrorT` is deprecated, and the `MonadFail` instance of `ExceptT` does not do the same thing.  The [`either-result`][] package could be used to resolve this, but I just added a `newtype` around `Either` to resolve it without adding a dependency.

[`either-result`]: <https://hackage.haskell.org/package/either-result>