### PR TITLE
Extend upper bounds of dependencies

### DIFF
--- a/ginger.cabal
+++ b/ginger.cabal
@@ -23,13 +23,13 @@ source-repository head
 
 common deps
   build-depends: base >=4.8 && <5
-               , aeson >=1.4.2.0 && <2.2
+               , aeson >=1.4.2.0 && <2.3
                , bytestring >=0.10.8.2 && <0.12
                , data-default >= 0.5 && <0.8
-               , mtl >= 2.2 && <2.3
+               , mtl >= 2.2 && <2.4
                , text >=1.2.3.1 && <2.1
                , time >= 0.1.6.0 && <1.13
-               , transformers >= 0.3 && <0.6
+               , transformers >= 0.3 && <0.7
                , unordered-containers >= 0.2.5 && <0.3
                , utf8-string >=1.0.1.1 && <1.1
 
@@ -54,10 +54,10 @@ library
                , filepath >= 1.3 && <1.5
                , http-types >= 0.8 && (< 0.11 || >= 0.12) && <0.13
                , parsec >= 3.0 && <3.2
-               , regex-tdfa >=1.2.3 && <=1.5
+               , regex-tdfa >=1.2.3 && <=1.4
                , safe >= 0.3 && <0.4
                , scientific >= 0.3 && <0.4
-               , vector >=0.12.0.2 && <0.13
+               , vector >=0.12.0.2 && <0.14
   if !impl(ghc >= 8.0)
     build-depends: semigroups == 0.18.*
   hs-source-dirs:      src
@@ -72,7 +72,7 @@ executable ginger
     hs-source-dirs: cli
     default-language:    Haskell2010
     build-depends: ginger
-                 , optparse-applicative >=0.14.3.0 && <0.18
+                 , optparse-applicative >=0.14.3.0 && <0.19
                  , process >=1.6.5.0 && <1.7
                  , yaml >=0.11.0.0 && <0.12
 


### PR DESCRIPTION
Commit [`eb33b2bd`][] extended the upper bounds of the [`mtl`][] and [`transformers`][] dependencies, but commit [`4f53cc8e`][] inadvertently reverted these changes when moving the constraints to a common stanza.  This PR fixes this as well as extends the upper bounds for some more dependencies.

The changes adjust the upper bounds of the following dependencies to support the latest versions:

* [`aeson`][] upper bound is extended
* [`mtl`][] upper bound is extended again
* [`optparse-applicative`][] upper bound is extended
* [`regex-tdfa`][] upper bound was too high and is fixed
* [`transformers`][] upper bound is extended again
* [`vector`][] upper bound is extended

Note that the [`bytestring`][] upper bound is *not* adjusted, as the latest version is not used in a released version of GHC yet, and the [`parsec`][] library does not support it yet.

Here is the `cabal.project` file that I used to test these versions.  IMHO, it might be worthwhile to commit this file (named `cabal-bounds-upper.project` or similar) to make it easy to adjust and test upper bounds as they change.

```
packages: ./ginger.cabal

with-compiler: ghc-9.6.2

constraints:
    aeson == 2.2.0.0
  , aeson-pretty == 0.8.10
  , base == 4.18.0.0
  , bytestring == 0.11.4.0
  , containers == 0.6.7
  , data-default == 0.7.1.1
  , filepath == 1.4.100.4
  , http-types == 0.12.3
  , mtl == 2.3.1
  , optparse-applicative == 0.18.1.0
  , parsec == 3.1.16.1
  , process == 1.6.17.0
  , regex-tdfa == 1.3.2.2
  , safe == 0.3.19
  , scientific == 0.3.7.0
  , semigroups == 0.20
  , tasty == 1.4.3
  , tasty-hunit == 0.10.0.3
  , tasty-quickcheck == 0.10.2
  , text == 2.0.2
  , time == 1.12.2
  , transformers == 0.6.1.1
  , unordered-containers == 0.2.19.1
  , utf8-string == 1.0.2
  , vector == 0.13.0.0
  , yaml == 0.11.11.2
```

If you have time to make a release that includes these changes, I would appreciate it.

[`aeson`]: <https://hackage.haskell.org/package/aeson>
[`bytestring`]: <https://hackage.haskell.org/package/bytestring>
[`mtl`]: <https://hackage.haskell.org/package/mtl>
[`optparse-applicative`]: <https://hackage.haskell.org/package/optparse-applicative>
[`parsec`]: <https://hackage.haskell.org/package/parsec>
[`transformers`]: <https://hackage.haskell.org/package/transformers>
[`regex-tdfa`]: <https://hackage.haskell.org/package/regex-tdfa>
[`vector`]: <https://hackage.haskell.org/package/vector>

[`eb33b2bd`]: <https://github.com/tdammers/ginger/commit/eb33b2bdb481d9fcc08e1d59722c52a79687e665>
[`4f53cc8e`]: <https://github.com/tdammers/ginger/commit/4f53cc8e458a167a365fb5c550f6329526c864c9>