### PR TITLE
Extend upper bounds of dependencies

### DIFF
--- a/ginger.cabal
+++ b/ginger.cabal
@@ -24,10 +24,10 @@ source-repository head
 common deps
   build-depends: base >=4.8 && <5
                , aeson >=1.4.2.0 && <2.3
-               , bytestring >=0.10.8.2 && <0.12
+               , bytestring >=0.10.8.2 && <0.13
                , data-default >= 0.5 && <0.8
                , mtl >= 2.2 && <2.4
-               , text >=1.2.3.1 && <2.1
+               , text >=1.2.3.1 && <2.2
                , time >= 0.1.6.0 && <1.13
                , transformers >= 0.3 && <0.7
                , unordered-containers >= 0.2.5 && <0.3
@@ -85,6 +85,6 @@ test-suite tests
     hs-source-dirs: test
     default-language: Haskell2010
     build-depends: ginger
-                 , tasty >=1.2 && <1.5
+                 , tasty >=1.2 && <1.6
                  , tasty-hunit >=0.10.0.1 && <0.11
                  , tasty-quickcheck >=0.10 && <0.11

--- a/ginger.cabal
+++ b/ginger.cabal
@@ -51,7 +51,7 @@ library
   -- other-extensions:
   build-depends: aeson-pretty >=0.8.7 && <0.9
                , containers >=0.6.4 && <0.7
-               , filepath >= 1.3 && <1.5
+               , filepath >= 1.3 && <1.6
                , http-types >= 0.8 && (< 0.11 || >= 0.12) && <0.13
                , parsec >= 3.0 && <3.2
                , regex-tdfa >=1.2.3 && <=1.4

--- a/ginger.cabal
+++ b/ginger.cabal
@@ -50,7 +50,7 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends: aeson-pretty >=0.8.7 && <0.9
-               , containers >=0.6.4 && <0.7
+               , containers >=0.6.4 && <0.8
                , filepath >= 1.3 && <1.6
                , http-types >= 0.8 && (< 0.11 || >= 0.12) && <0.13
                , parsec >= 3.0 && <3.2


### PR DESCRIPTION
The following dependency upper bounds are extended:

* `bytestring` (tested `0.12.1.0`)
* `text` (tested `2.1.1`)
* `tasty` (tested `1.5`)

No changes to the code are necessary.  With the extended bounds, Ginger works fine with GHC 9.8.2 (latest release, now used by Stackage Nightly).